### PR TITLE
fix: add joints dynamical parameters for gazebo simulation

### DIFF
--- a/tm_description/xacro/macro.tm12-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm12-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm12x-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm12x-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm14-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm14-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm14x-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm14x-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm5-700-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm5-700-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm5-900-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm5-900-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm5x-700-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm5x-700-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>

--- a/tm_description/xacro/macro.tm5x-900-nominal.urdf.xacro
+++ b/tm_description/xacro/macro.tm5x-900-nominal.urdf.xacro
@@ -25,7 +25,7 @@
     safety_limits:=false safety_pos_margin:=0.15
     safety_k_position:=20">
 
-   <xacro:property name="damping_factor" value="0.000"/>
+   <xacro:property name="damping_factor" value="600.000"/>
    <xacro:property name="d1" value="${damping_factor*0.1}"/>
    <xacro:property name="d2" value="${damping_factor*0.1}"/>
    <xacro:property name="d3" value="${damping_factor*0.1}"/>
@@ -33,7 +33,7 @@
    <xacro:property name="d5" value="${damping_factor*0.1}"/>
    <xacro:property name="d6" value="${damping_factor*0.1}"/>
 
-   <xacro:property name="friction_factor" value="0.000"/>
+   <xacro:property name="friction_factor" value="40.000"/>
    <xacro:property name="f1" value="${friction_factor*0.1}"/>
    <xacro:property name="f2" value="${friction_factor*0.1}"/>
    <xacro:property name="f3" value="${friction_factor*0.1}"/>


### PR DESCRIPTION
To achieve a stable behavior of the robot controlled in gazebo simulation the dynamical parameters of the joints are adjusted as suggested [here](https://github.com/ros-controls/gazebo_ros2_control/issues/73#issuecomment-1120787488)